### PR TITLE
reduce lock problems

### DIFF
--- a/ldms/src/store/stream/stream_csv_store.c
+++ b/ldms/src/store/stream/stream_csv_store.c
@@ -187,8 +187,8 @@ struct csv_stream_handle{
         int64_t byte_count; //for the roll. Cumulative since last roll
         struct timeval tlastrcv; //for the flush.
         struct linedata dataline; //used to keep track of keys for the header
-        ldmsd_stream_client_t client; //subscribe/unsubscribe
-        pthread_mutex_t lock;
+        pthread_mutex_t lock; /* protects items above, not client below. */
+        ldmsd_stream_client_t client; //subscribe/unsubscribe handle cached
 };
 
 
@@ -235,14 +235,15 @@ static void close_streamstore(void *obj, void *cb_arg){
                 return;
         }
 
-        pthread_mutex_lock(&stream_handle->lock);
-        msglog(LDMSD_LDEBUG, PNAME ": Closing stream store <%s>\n",
-               stream_handle->stream);
-
         /* unsubscribe */
         if (stream_handle->client)
                 ldmsd_stream_close(stream_handle->client);
         stream_handle->client = NULL;
+
+        pthread_mutex_lock(&stream_handle->lock);
+        msglog(LDMSD_LDEBUG, PNAME ": Closing stream store <%s>\n",
+               stream_handle->stream);
+
 
         if (stream_handle->file) {
                 fflush(stream_handle->file);
@@ -730,7 +731,7 @@ static int stream_cb(ldmsd_stream_client_t c, void *ctxt,
 		     const char *msg, size_t msg_len,
 		     json_entity_t e) {
 
-        struct csv_stream_handle* stream_handle;
+        struct csv_stream_handle* stream_handle = ctxt;
         struct timeval tv_prev;
         int gottime = 0;
 	int rc = 0;
@@ -763,21 +764,14 @@ static int stream_cb(ldmsd_stream_client_t c, void *ctxt,
                 return -1;
         }
 
-        pthread_mutex_lock(&cfg_lock); /** lock needed for clean shutdown */
-        stream_handle = idx_find(stream_idx, (void *)skey, strlen(skey));
         if (!stream_handle){
                 msglog(LDMSD_LERROR,
                        PNAME ": No stream_store for '%s'\n", skey);
-                pthread_mutex_unlock(&cfg_lock);
                 return -1;
 
         }
 
 	pthread_mutex_lock(&stream_handle->lock);
-        pthread_mutex_unlock(&cfg_lock);
-        /** currently releasing this, since the only way to destroy is in the
-            overall shutdown, plus want to be able to do the callback on
-            independent streams at the same time */
 
 
 #ifdef TIMESTAMP_STORE
@@ -940,7 +934,6 @@ static int open_streamstore(char* stream){
         }
 
        	pthread_mutex_init(&stream_handle->lock, NULL);
-	pthread_mutex_lock(&stream_handle->lock);
 
         //swap
         stream_handle->file = tmp_file;
@@ -955,7 +948,6 @@ static int open_streamstore(char* stream){
         msglog(LDMSD_LDEBUG, PNAME ": subscribing to stream '%s'\n", stream);
         stream_handle->client = ldmsd_stream_subscribe(stream, stream_cb, stream_handle);
         idx_add(stream_idx, (void *)stream, strlen(stream), stream_handle);
-	pthread_mutex_unlock(&stream_handle->lock);
 
 	goto out;
 
@@ -1412,24 +1404,7 @@ static int config(struct ldmsd_plugin *self,
         }
 
 
-        /*
-
-        //subscribe to each one
-        templist = strdup(streamlist);
-        if (!templist){
-                rc = ENOMEM;
-                goto out;
-        }
-        pch = strtok_r(templist, ",", &saveptr);
-        while (pch != NULL){
-                msglog(LDMSD_LDEBUG,
-                       PNAME ": subscribing to stream '%s'\n", pch);
-                ldmsd_stream_subscribe(pch, stream_cb, self);
-                pch = strtok_r(NULL, ",", &saveptr);
-	}
-        */
-
-        goto out;
+       goto out;
 
 
 err:


### PR DESCRIPTION
The current implementation has an observed deadlock between the close_streamstore:ldmsd_stream_close and stream_cb.
It hangs while exiting if events are being delivered.
There is a lock protecting the stream (s_lock) underlying the stream client and lock on the csv_stream_handle that can easily get stuck waiting on each other during term if messages are being delivered. (gdb stacks included at end). Term and stream_cb are always in separate threads, it appears.

A (maybe not wonderful) workaround for this deadlock is to move the mutex_lock call in close_streamstore to after the ldmsd_stream_close call. Doing so eliminates the deadlock, but potentially leaves stream_cb calling mutex_lock on a destroyed mutex and handling a bad object. I have not been able to force an instance of using the use-after-free, however. What we really need is some way for unifying the client's per-stream lock with the underlying ldmsd stream lock for delivery and close. 

Secondarily, the current implementation has unnecessary mutex_lock calls this patch removes:
* protecting unneeded use of  stream_idx with cfg_lock in stream_cb (avoidable by using the callback ctxt).
* protecting stream_handle in open_streamstore  where it is not yet accessible.

stacks:
event deivery:
```
#0  0x00007f06ca89c54d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f06ca897e9b in _L_lock_883 () from /lib64/libpthread.so.0
#2  0x00007f06ca897d68 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00007f06c8563a70 in stream_cb (c=<optimized out>, ctxt=0x2569140, stream_type=LDMSD_STREAM_JSON, 
    msg=0x7f06c0111fc4 "{\"job-id\" : 10364, \"rank\" : 1, \"kokkos-perf-data\" : [ {\"name\" : \"SPARTAFOO0\", \"count\": 0, \"time\": 0.0000},{\"name\" : \"SPARTAFOO1\", \"count\": 1, \"time\": 0.0001},{\"name\" : \"SPARTAFOO2\", \"count\": 2, \"time\""..., msg_len=<optimized out>, e=0x7f06c0111670)
    at ../../../../../ldms/src/store/stream/stream_csv_store.c:772
#4  0x00007f06cc719532 in ldmsd_stream_deliver (stream_name=stream_name@entry=0x7f06c03123d0 "baz", 
    stream_type=LDMSD_STREAM_JSON, 
    data=0x7f06c0111fc4 "{\"job-id\" : 10364, \"rank\" : 1, \"kokkos-perf-data\" : [ {\"name\" : \"SPARTAFOO0\", \"count\": 0, \"time\": 0.0000},{\"name\" : \"SPARTAFOO1\", \"count\": 1, \"time\": 0.0001},{\"name\" : \"SPARTAFOO2\", \"count\": 2, \"time\""..., data_len=578, entity=0x7f06c0111670, entity@entry=0x0)
    at ../../../../ldms/src/ldmsd/ldmsd_stream.c:102
#5  0x000000000041259b in stream_publish_handler (reqc=0x7f06c03127c0)
    at ../../../../ldms/src/ldmsd/ldmsd_request.c:6040
#6  0x0000000000418087 in ldmsd_handle_request (reqc=reqc@entry=0x7f06c03127c0)
    at ../../../../ldms/src/ldmsd/ldmsd_request.c:862
#7  0x00000000004185c0 in ldmsd_process_config_request (xprt=xprt@entry=0x7f06c7d2b990, 
    request=request@entry=0x7f06c00008ec) at ../../../../ldms/src/ldmsd/ldmsd_request.c:1174
#8  0x000000000040f0ab in ldmsd_recv_msg (x=<optimized out>, data=0x7f06c00008ec "\377\377\377\377", 
    data_len=<optimized out>) at ../../../../ldms/src/ldmsd/ldmsd_config.c:961
#9  0x00007f06ccb389dd in process_send_request (req=0x7f06c00008d8, x=0x7f06c0111300)
    at ../../../../ldms/src/core/ldms_xprt.c:896
#10 ldms_xprt_recv_request (req=0x7f06c00008d8, x=0x7f06c0111300) at ../../../../ldms/src/core/ldms_xprt.c:1584
#11 recv_cb (r=0x7f06c00008d8, x=0x7f06c0111300) at ../../../../ldms/src/core/ldms_xprt.c:2031
#12 ldms_zap_cb (zep=zep@entry=0x7f06c0111d60, ev=ev@entry=0x7f06c7d2bd00)
    at ../../../../ldms/src/core/ldms_xprt.c:2722
#13 0x00007f06ccb39c5b in ldms_zap_auto_cb (zep=0x7f06c0111d60, ev=0x7f06c7d2bd00)
    at ../../../../ldms/src/core/ldms_xprt.c:2862
#14 0x00007f06c835a493 in process_sep_msg_sendrecv (sep=<optimized out>)
    at ../../../../../lib/src/zap/sock/zap_sock.c:591
#15 0x00007f06c835d101 in sock_read (ev=0x257f7b4) at ../../../../../lib/src/zap/sock/zap_sock.c:1354
#16 sock_ev_cb (ev=0x257f7b4) at ../../../../../lib/src/zap/sock/zap_sock.c:1149
#17 0x00007f06c835dc35 in io_thread_proc (arg=0x257f750) at ../../../../../lib/src/zap/sock/zap_sock.c:1405
#18 0x00007f06ca895ea5 in start_thread () from /lib64/libpthread.so.0
#19 0x00007f06cafaf9fd in clone () from /lib64/libc.so.6
```

and stream close:
```
#0  0x00007f06ca89c54d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f06ca897e9b in _L_lock_883 () from /lib64/libpthread.so.0
#2  0x00007f06ca897d68 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00007f06cc7197e1 in ldmsd_stream_close (c=0x2569610) at ../../../../ldms/src/ldmsd/ldmsd_stream.c:184
#4  0x00007f06c85629d1 in close_streamstore (obj=0x2569140, cb_arg=<optimized out>)
    at ../../../../../ldms/src/store/stream/stream_csv_store.c:244
#5  0x00007f06cb8ea095 in traverse_layer (t=t@entry=0x2561850, pl=pl@entry=0x2567e70, 
    cb=cb@entry=0x7f06c8562990 <close_streamstore>, cb_arg=cb_arg@entry=0x0)
    at ../../../../lib/src/coll/idx.c:172
#6  0x00007f06cb8ea0ab in traverse_layer (t=t@entry=0x2561850, pl=pl@entry=0x2566e60, 
    cb=cb@entry=0x7f06c8562990 <close_streamstore>, cb_arg=cb_arg@entry=0x0)
    at ../../../../lib/src/coll/idx.c:174
#7  0x00007f06cb8ea0ab in traverse_layer (t=0x2561850, pl=0x2562a20, 
    cb=cb@entry=0x7f06c8562990 <close_streamstore>, cb_arg=cb_arg@entry=0x0)
    at ../../../../lib/src/coll/idx.c:174
#8  0x00007f06cb8ea32f in idx_traverse (t=<optimized out>, cb=cb@entry=0x7f06c8562990 <close_streamstore>, 
    cb_arg=cb_arg@entry=0x0) at ../../../../lib/src/coll/idx.c:184
#9  0x00007f06c8562896 in term (self=self@entry=0x0)
    at ../../../../../ldms/src/store/stream/stream_csv_store.c:1449
#10 0x00007f06c856261b in stream_csv_store_fini ()
    at ../../../../../ldms/src/store/stream/stream_csv_store.c:1513
#11 0x00007f06ccd5408a in _dl_fini () from /lib64/ld-linux-x86-64.so.2
#12 0x00007f06caeeace9 in __run_exit_handlers () from /lib64/libc.so.6
#13 0x00007f06caeead37 in exit () from /lib64/libc.so.6
#14 0x000000000040bb18 in cleanup (x=x@entry=0, reason=reason@entry=0x4266f5 "signal to exit caught")
    at ../../../../ldms/src/ldmsd/ldmsd.c:494
#15 0x000000000040bb97 in cleanup_sa (signal=<optimized out>, info=0x7ffe8fe655b0, arg=<optimized out>)
    at ../../../../ldms/src/ldmsd/ldmsd.c:549
#16 <signal handler called>
#17 0x00007f06caf768ed in nanosleep () from /lib64/libc.so.6
#18 0x00007f06cafa71c4 in usleep () from /lib64/libc.so.6
#19 0x000000000040a302 in main (argc=11, argv=<optimized out>) at ../../../../ldms/src/ldmsd/ldmsd.c:2199
```